### PR TITLE
fix: improve bookmarks.md documentation

### DIFF
--- a/docs/configs/bookmarks.md
+++ b/docs/configs/bookmarks.md
@@ -3,7 +3,7 @@ title: Bookmarks
 description: Bookmark Configuration
 ---
 
-Bookmarks function much the same as [Services](services.md), in how groups and lists work. They're just much simpler, smaller, and contain no extra features other than being a link out.
+Bookmarks are configured in the `bookmarks.yaml` file. They function much the same as [Services](services.md), in how groups and lists work. They're just much simpler, smaller, and contain no extra features other than being a link out.
 
 The design of homepage expects `abbr` to be 2 letters, but is not otherwise forced.
 
@@ -12,6 +12,7 @@ You can also use an icon for bookmarks similar to the [options for service icons
 By default, the description will use the hostname of the link, but you can override it with a custom description.
 
 ```yaml
+---
 - Developer:
     - Github:
         - abbr: GH
@@ -29,4 +30,8 @@ By default, the description will use the hostname of the link, but you can overr
           href: https://youtube.com/
 ```
 
+which renders to (depending on your theme, etc.):
+
 <img width="1000" alt="Bookmarks" src="https://user-images.githubusercontent.com/19408/269307009-d7e45885-230f-4e07-b421-9822017ae878.png">
+
+The default [bookmarks.yaml](https://github.com/gethomepage/homepage/blob/main/src/skeleton/bookmarks.yaml) is a working example.


### PR DESCRIPTION
## Proposed change
Improve documentation, working examples for bookmarks.
I stumbled to get Homepage working because the example omitted the configuration filename and [YAML: start of document](https://yaml.org/spec/1.2.2/#22-structures).

## Type of change
- [x] Documentation only

## Checklist:
- [X] If applicable, I have added corresponding documentation changes.
